### PR TITLE
Cf worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # mcp-seatable
 
-A comprehensive MCP (Model Context Protocol) server that provides full SeaTable database access through 18+ powerful tools. Deploy anywhere: traditional CLI, local SSE server, or scalable Cloudflare Workers.
+A comprehensive MCP (Model Context Protocol) server that provides full SeaTable dat```javascript
+// Connect to your deployed Worker instance
+const mcpClient = new MCPClient('https://your-worker-name.your-account.workers.dev/mcp');se access through 18+ powerful tools. Deploy anywhere: traditional CLI, local SSE server, or scalable Cloudflare Workers.
 
 ## 🚀 Deployment Options
 
 ### Option 1: Cloudflare Workers (Recommended for Production)
-
-**Live Demo**: `https://mcp-seatable.brian-money.workers.dev`
 
 Deploy your own scalable MCP server on Cloudflare Workers with session persistence and dual transport support:
 
@@ -17,8 +17,8 @@ cd mcp-seatable
 npm install
 npx wrangler deploy
 
-# Or use the live instance directly
-npx mcp-remote https://mcp-seatable.brian-money.workers.dev/sse
+# After deployment, use your worker URL
+npx mcp-remote https://your-worker-name.your-account.workers.dev/sse
 ```
 
 **Features:**

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ Add to `claude_desktop_config.json`:
 ### For Web Applications (Cloudflare Worker)
 
 ```javascript
-// Connect to the live Worker instance
-const mcpClient = new MCPClient('https://mcp-seatable.brian-money.workers.dev/mcp')
+// Connect to your deployed Worker instance
+const mcpClient = new MCPClient('https://your-worker-name.your-account.workers.dev/mcp')
 await mcpClient.initialize()
 const tables = await mcpClient.callTool('list_tables', {})
 ```


### PR DESCRIPTION
This pull request updates the `README.md` to remove references to the previous live demo endpoint and instead guide users to use their own deployed Cloudflare Worker URLs. This makes the documentation more generic and applicable to anyone deploying their own instance.